### PR TITLE
Updates bargain-stocks.user.js to work on all stock list pages

### DIFF
--- a/bargain-stocks.user.js
+++ b/bargain-stocks.user.js
@@ -2,9 +2,9 @@
 // @name         Neopets: Show Best Bargain Stocks
 // @author       Hiddenist
 // @namespace    https://hiddenist.com
-// @version      0.1
+// @version      0.2
 // @description  Shows a list of the best priced stocks on the Neopets bargain stocks page
-// @match        http*://www.neopets.com/stockmarket.phtml?type=list&bargain=true*
+// @match        http*://www.neopets.com/stockmarket.phtml?type=list*
 // @grant        none
 // @updateURL    https://github.com/Meerca/Neopets-Userscripts/raw/main/bargain-stocks.user.js
 // ==/UserScript==


### PR DESCRIPTION
Updates the match filter on the Bargain Stocks script so that it works on both the [bargain stocks list](https://www.neopets.com/stockmarket.phtml?type=list&bargain=true) and [full stocks list](https://www.neopets.com/stockmarket.phtml?type=list&full=true) pages, rather than only the bargain stocks one.

Thanks to @cdyz94 for pointing this out in #1